### PR TITLE
Allow deep nesting of locales

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ module.exports = function jsonBundler(opts) {
 
   function gatherJson(chunc, enc, cb) {
     var localePath = path.relative(chunc.base, path.dirname(chunc.path)).replace(new RegExp(omit, 'g'), '');
-    // remove trailing slash
-    localePath = localePath.replace(/\/$/, '');
+
+    // remove first and last slash
+    localePath = localePath.replace(/^\/|\/$/g, '');
     var fileName = path.basename(chunc.path);
     var content = {};
     objectPath.set(content, localePath.replace(/\//g, '.'), JSON.parse(chunc.contents));

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ module.exports = function jsonBundler(opts) {
   return through.obj(gatherJson, bundleJson);
 
   function gatherJson(chunc, enc, cb) {
-    var localePath = path.relative(chunc.base, path.dirname(chunc.path)).replace(omit, '');
+    var localePath = path.relative(chunc.base, path.dirname(chunc.path)).replace(new RegExp(omit, 'g'), '');
     // remove trailing slash
     localePath = localePath.replace(/\/$/, '');
     var fileName = path.basename(chunc.path);
     var content = {};
-    objectPath.set(content, localePath.replace('/', '.'), JSON.parse(chunc.contents));
+    objectPath.set(content, localePath.replace(/\//g, '.'), JSON.parse(chunc.contents));
 
     contents[fileName] = contents[fileName] || {};
     deepAssign(contents[fileName], content);


### PR DESCRIPTION
In the case I have a locale file in the folder `Element1/Element2/Element3/locales/en-US.json` it will transform it into `{ "Element1": { "Element2": { "Element3": { } } }`

To avoid empty object while nesting element, better use RegExp to omit elements including slashes:

```
pipe(jsonBundler({
    omit: /\/locales|\/components/
  }))
```

Not sure if we should add the slash in the gulp module
